### PR TITLE
[수정] 브랜드스토리 Outro 수정

### DIFF
--- a/src/component/brandStory/Outro.jsx
+++ b/src/component/brandStory/Outro.jsx
@@ -30,7 +30,7 @@ const Pretendard28 = styled(BasePretendard26)`
   margin-top: ${vwCalc(18)};
   font-family: Pretendard;
   font-size: ${vwCalc(28)};
-  line-height: 1.5;
+  line-height: 153%;
 `;
 
 const ScrollTopButton = styled.button`
@@ -60,7 +60,8 @@ const SquareLink = styled(BaseShape).attrs({
   width: ${vwCalc(568)};
   height: ${vwCalc(473)};
   font-weight: 600;
-  background: ${(props) => props.$background};
+  background-image: ${(props) => props.$background};
+  background-size: cover;
   border-radius: ${vwCalc(33)};
   text-align: center;
 `;

--- a/src/component/style/BasePoppins.jsx
+++ b/src/component/style/BasePoppins.jsx
@@ -2,8 +2,8 @@ import styled from "styled-components";
 import { colors, fontSize } from "../../styles";
 
 const fontSizes = {
-  small: `clamp(20px, ${fontSize.eSizeText}, 100px)`,
-  large: `clamp(70px, ${fontSize.eSizeHead}, 150px)`,
+  small: fontSize.eSizeText,
+  large: fontSize.eSizeHead,
 };
 
 export const BasePoppins = styled.p`

--- a/src/component/style/BasePretendard.jsx
+++ b/src/component/style/BasePretendard.jsx
@@ -3,9 +3,9 @@ import vwCalc from "../../util/vwCalc";
 import { colors, fontSize } from "../../styles";
 
 const fontSizes = {
-  small: `clamp(8px, ${fontSize.kSizeText20}, 20px)`,
-  medium: `clamp(14px, ${fontSize.kSizeHead}, 26px)`,
-  large: `clamp(23px, ${vwCalc(35)}, 35px)`,
+  small: fontSize.kSizeText20,
+  medium: fontSize.kSizeHead,
+  large: vwCalc(35),
 };
 
 export const BasePretendard = styled.p`


### PR DESCRIPTION
## 변경사항

아이맥 해상도로 인해 깨지는 부분
- 브랜드스토리 Outro 배경이미지 `cover` 적용
- 폰트(Poppins, Pretendard) 최소최댓값 삭제